### PR TITLE
Added cloud_properties argument to create_disk

### DIFF
--- a/bosh_vcloud_cpi.gemspec
+++ b/bosh_vcloud_cpi.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
   s.name         = "bosh_vcloud_cpi"
-  s.version      = "0.5.5"
+  s.version      = "0.6.0"
   s.platform     = Gem::Platform::RUBY
   s.summary      = "BOSH vCloud CPI"
   s.description  = "BOSH vCloud CPI\n#{`git rev-parse HEAD`[0, 6]}"

--- a/lib/cloud/vcloud/cloud.rb
+++ b/lib/cloud/vcloud/cloud.rb
@@ -223,8 +223,8 @@ module VCloudCloud
       end
     end
 
-    def create_disk(size_mb, vm_locality = nil)
-      (steps "create_disk(#{size_mb}, #{vm_locality.inspect})" do |s|
+    def create_disk(size_mb, cloud_properties, vm_locality = nil)
+      (steps "create_disk(#{size_mb}, #{cloud_properties.inspect}, #{vm_locality.inspect})" do |s|
         # vm_locality is used as vm_id
         vm = vm_locality.nil? ? nil : client.resolve_entity(vm_locality)
         storage_profiles = client.vdc.storage_profiles || []

--- a/spec/integration/lifecycle_spec.rb
+++ b/spec/integration/lifecycle_spec.rb
@@ -101,7 +101,7 @@ describe VCloudCloud::Cloud do
     @vm_id.should_not be_nil
     cpi.has_vm?(@vm_id).should be(true)
 
-    @disk_id = cpi.create_disk(2048, @vm_id)
+    @disk_id = cpi.create_disk(2048, {}, @vm_id)
     @disk_id.should_not be_nil
 
     cpi.attach_disk(@vm_id, @disk_id)
@@ -122,7 +122,7 @@ describe VCloudCloud::Cloud do
 
     cpi.has_vm?(@vm_id2).should be(true)
 
-    @disk_id2 = cpi.create_disk(2048, @vm_id2)
+    @disk_id2 = cpi.create_disk(2048, {}, @vm_id2)
     @disk_id2.should_not be_nil
 
     cpi.attach_disk(@vm_id2, @disk_id2)
@@ -152,7 +152,7 @@ describe VCloudCloud::Cloud do
     end
 
     context 'with existing disks' do
-      before { @existing_volume_id = cpi.create_disk(2048) }
+      before { @existing_volume_id = cpi.create_disk(2048, {}) }
       after { cpi.delete_disk(@existing_volume_id) if @existing_volume_id }
 
       it 'should exercise the vm lifecycle' do

--- a/spec/integration/vcloud_cpi_spec.rb
+++ b/spec/integration/vcloud_cpi_spec.rb
@@ -5,7 +5,9 @@ require_relative '../../lib/cloud/vcloud/steps/instantiate'
 describe 'vCloud CPI' do
 
   before :all do
-    @target = CpiHelper::Target.new ENV['TEST_SETTINGS']
+    settings = ENV['TEST_SETTINGS'] || raise('Missing TEST_SETTINGS')
+
+    @target = CpiHelper::Target.new settings
     @cfg = @target.cfg
     @logger = @target.logger
 
@@ -68,9 +70,10 @@ describe 'vCloud CPI' do
         end
         if vm['disk']
           size = vm['disk']['size'].to_i
+          cloud_properties = vm['disk'].fetch('cloud_properties', {})
           locality = vm['disk']['locality'] ? vm_id : nil
-          @logger.info "create_disk(#{size}, #{locality})"
-          disk_id = @cpi.create_disk size, locality
+          @logger.info "create_disk(#{size}, #{cloud_properties.inspect}, #{locality})"
+          disk_id = @cpi.create_disk size, cloud_properties, locality
           disk_id.should_not be_nil
           @logger.info "attach_disk(#{vm_id}, #{disk_id})"
           @cpi.attach_disk vm_id, disk_id

--- a/spec/unit/vcloud/cloud_spec.rb
+++ b/spec/unit/vcloud/cloud_spec.rb
@@ -367,7 +367,7 @@ module VCloudCloud
         trx.stub_chain("state.[]").with(:disk).and_return disk
         disk.stub(:urn).and_return result
 
-        subject.create_disk(size_mb).should == result
+        subject.create_disk(size_mb, {}).should == result
       end
 
       it "create disk with vm locality" do
@@ -382,7 +382,7 @@ module VCloudCloud
         trx.stub_chain("state.[]").with(:disk).and_return disk
         disk.stub(:urn).and_return result
 
-        subject.create_disk(size_mb, vm_locality).should == result
+        subject.create_disk(size_mb, {}, vm_locality).should == result
       end
     end
 

--- a/spec/unit/vcloud_spec.rb
+++ b/spec/unit/vcloud_spec.rb
@@ -5,7 +5,7 @@ describe Bosh::Clouds::VCloud do
     cpi_methods = Bosh::Cloud.instance_methods - Object.instance_methods
     vcloud_methods = described_class.instance_methods - Object.instance_methods
     # skip the APIs that vcloud doesn't suport
-    unsupported_methods = [:current_vm_id, :delete_snapshot,
+    unsupported_methods = [:current_vm_id, :delete_snapshot, :has_disk?,
                            :get_disks, :set_vm_metadata, :snapshot_disk]
     missing_methods = cpi_methods - vcloud_methods - unsupported_methods
 


### PR DESCRIPTION
- bumped version to 0.6.0 due to reverse incompatibility
- improved vcloud_cpi_spec error when missing env vars
- added cloud.has_disk? to the unsupported list to make unit tests pass

This will need to be pushed as a new gem so that we (Pivotal BOSH team) can complete the create_disk change without breaking vcloud. This change is being made in BOSH to be able to support different kinds of persistent disks in the future, like SSDs (aws) and thin-provisioning (vsphere).

I haven't run the integration or lifecycle tests on the bosh_vcloud_cpi due to not having a vcloud account. 

The BOSH acceptance tests (bats) will need to be run as well, after bumping bosh_vcloud_cpi in the director/micro gemspecs. 

For use with this BOSH branch: 
https://github.com/cloudfoundry/bosh/tree/disk-cloud-properties
