### PR TITLE
upgrade nokogiri dependency to support traveling-ruby nokogiri 1.6.5

### DIFF
--- a/bosh_vcloud_cpi.gemspec
+++ b/bosh_vcloud_cpi.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency "builder","~>3.1.4"
   s.add_dependency "httpclient", "~>2.4.0"
   s.add_dependency "rest-client", "~>1.6.7"
-  s.add_dependency "nokogiri", "~>1.5.6"
+  s.add_dependency "nokogiri", '>= 1.5', '< 2.0'
   s.add_dependency "membrane"
 end


### PR DESCRIPTION
The available pre-built native C gems for traveling-ruby include only nokogiri 1.6.5. Can you please support 1.6.5?

This patch will continue to support 1.5 + also 1.6.5. It caps the support at anything before 2.0 version in future.
