### PR TITLE
Update file_uploader.rb

### DIFF
--- a/lib/cloud/vcloud/file_uploader.rb
+++ b/lib/cloud/vcloud/file_uploader.rb
@@ -22,7 +22,8 @@ module VCloudCloud
         headers['Content-Length'] = size.to_s
         headers['Transfer-Encoding'] = 'chunked'
         request_type = Net::HTTP.const_get(http_method)
-        request = request_type.new(href, headers)
+        uri = URI(href)
+        request = request_type.new(uri.path, headers)
         request.body_stream = stream
         request
       end


### PR DESCRIPTION
update request object creation to use URI (path) instead of a full URL. The full URL creates an redirect to /login in VCGS (gov equivalent of vCloud Air).  The redirect leads to an incomplete upload of the stemcell images. According to the API docs for creating a request, the URI.path should be used. This change has been tested on both VCHS (vCloud Air) and VCGS (vCloud Air Government Services)