### PR TITLE
Adding in checks to account for tasks that might not be running yet.

### DIFF
--- a/lib/cloud/vcloud/steps/insert_catalog_media.rb
+++ b/lib/cloud/vcloud/steps/insert_catalog_media.rb
@@ -10,7 +10,7 @@ module VCloudCloud
         client.timed_loop do
           media = client.reload media
           vm = client.reload vm
-          if media.running_tasks.empty?
+          if media.running_tasks.empty? && media.prerunning_tasks.empty?
             client.invoke_and_wait :post, vm.insert_media_link,
                     :payload => params,
                     :headers => { :content_type => VCloudSdk::Xml::MEDIA_TYPE[:MEDIA_INSERT_EJECT_PARAMS] }

--- a/lib/cloud/vcloud/vcd_client.rb
+++ b/lib/cloud/vcloud/vcd_client.rb
@@ -145,6 +145,10 @@ module VCloudCloud
     end
 
     def wait_entity(entity, accept_failure = false)
+      entity.prerunning_tasks.each do |task|
+        wait_task task, accept_failure
+      end if entity.prerunning_tasks && !entity.prerunning_tasks.empty?
+
       entity.running_tasks.each do |task|
         wait_task task, accept_failure
       end if entity.running_tasks && !entity.running_tasks.empty?

--- a/lib/cloud/vcloud/xml/wrapper_classes/disk.rb
+++ b/lib/cloud/vcloud/xml/wrapper_classes/disk.rb
@@ -24,6 +24,10 @@ module VCloudSdk
         @root["size"].to_i/1024/1024
       end
 
+      def prerunning_tasks
+        tasks.find_all {|t| TASK_STATUS[:QUEUED].include?(t.status) || TASK_STATUS[:PRE_RUNNING].include?(t.status)}
+      end
+
       def running_tasks
         tasks.find_all {|t| RUNNING.include?(t.status)}
       end

--- a/lib/cloud/vcloud/xml/wrapper_classes/media.rb
+++ b/lib/cloud/vcloud/xml/wrapper_classes/media.rb
@@ -44,6 +44,11 @@ module VCloudSdk
         get_nodes("Link", {"rel" => "remove"}, true).first
       end
 
+      def prerunning_tasks
+        get_nodes("Task", {"status" => "queued"})
+          .concat(get_nodes("Task", {"status" => "preRunning"}))
+      end
+
       def running_tasks
         get_nodes("Task", {"status" => "running"})
       end

--- a/lib/cloud/vcloud/xml/wrapper_classes/vapp.rb
+++ b/lib/cloud/vcloud/xml/wrapper_classes/vapp.rb
@@ -33,6 +33,11 @@ module VCloudSdk
         fix_if_invalid(link, "remove", "", href)
       end
 
+      def prerunning_tasks
+        get_nodes("Task", {"status" => "queued"})
+          .concat(get_nodes("Task", {"status" => "preRunning"}))
+      end
+
       def running_tasks
         get_nodes("Task", {"status" => "running"})
       end


### PR DESCRIPTION
Many of the operations assumed that after tasks were submitted with vCD that they would be in a "running" status when checked again, and that if they weren't, then they must be completed.  This commit handles tasks that were submitted, but haven't yet started running, and allows them to start running before assuming they have completed.