### PR TITLE
Handle old failed tasks on vCloud Entities

### DIFF
--- a/lib/cloud/vcloud/xml/wrapper_classes/task.rb
+++ b/lib/cloud/vcloud/xml/wrapper_classes/task.rb
@@ -32,6 +32,10 @@ module VCloudSdk
         return task_progress.content unless task_progress.nil?
         nil
       end
+      
+      def start_time
+        Time.parse(self["startTime"])
+      end
     end
 
   end

--- a/spec/assets/existing_vapp_template_instantiate_old_tasks_response.xml
+++ b/spec/assets/existing_vapp_template_instantiate_old_tasks_response.xml
@@ -1,0 +1,34 @@
+<VApp xmlns="http://www.vmware.com/vcloud/v1.5" deployed="false" status="0" name="%s" id="urn:vcloud:vapp:%s" type="application/vnd.vmware.vcloud.vApp+xml" href="%s/api/vApp/vapp-%s" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.20.46.172/api/v1.5/schema/master.xsd">
+    <Link rel="down" type="application/vnd.vmware.vcloud.controlAccess+xml" href="%s/api/vApp/vapp-%s/controlAccess/"/>
+    <Link rel="up" type="application/vnd.vmware.vcloud.vdc+xml" href="%s/api/vdc/%s"/>
+    <Link rel="down" type="application/vnd.vmware.vcloud.owner+xml" href="%s/api/vApp/vapp-%s/owner"/>
+    <Link rel="down" type="application/vnd.vmware.vcloud.metadata+xml" href="%s/api/vApp/vapp-%s/metadata"/>
+    <Description>test</Description>
+    <Tasks>
+        <Task status="error" startTime="2011-08-29T09:21:36.484-07:00" operationName="vdcInstantiateVapp" operation="Creating Virtual Application %s(%s)" expiryTime="2011-11-27T11:21:36.484-08:00" name="task" id="urn:vcloud:task:%s" type="application/vnd.vmware.vcloud.task+xml" href="%s/api/task/1">
+            <Link rel="task:cancel" href="%s/api/task/%s/action/cancel"/>
+            <Owner type="application/vnd.vmware.vcloud.vApp+xml" name="%s" href="%s/api/vApp/vapp-%s"/>
+            <User type="application/vnd.vmware.admin.user+xml" name="vcap" href="%s/api/admin/user/42cbe98d-48da-4f5d-944e-596843a9fcb5"/>
+            <Organization type="application/vnd.vmware.vcloud.org+xml" name="%s" href="%s/api/org/b689c06e-1de0-4fd1-a5a3-050c479546ac"/>
+            <Progress>1</Progress>
+        </Task>
+        <Task status="error" startTime="2011-08-27T08:21:36.484-07:00" operationName="vdcInstantiateVapp" operation="Creating Virtual Application %s(%s)" expiryTime="2011-11-27T11:21:36.484-08:00" name="task" id="urn:vcloud:task:%s" type="application/vnd.vmware.vcloud.task+xml" href="%s/api/task/2">
+            <Link rel="task:cancel" href="%s/api/task/%s/action/cancel"/>
+            <Owner type="application/vnd.vmware.vcloud.vApp+xml" name="%s" href="%s/api/vApp/vapp-%s"/>
+            <User type="application/vnd.vmware.admin.user+xml" name="vcap" href="%s/api/admin/user/42cbe98d-48da-4f5d-944e-596843a9fcb5"/>
+            <Organization type="application/vnd.vmware.vcloud.org+xml" name="%s" href="%s/api/org/b689c06e-1de0-4fd1-a5a3-050c479546ac"/>
+            <Progress>1</Progress>
+        </Task>
+        <Task status="running" startTime="2011-08-29T11:21:36.484-07:00" operationName="vdcInstantiateVapp" operation="Creating Virtual Application %s(%s)" expiryTime="2011-11-27T11:21:36.484-08:00" name="task" id="urn:vcloud:task:%s" type="application/vnd.vmware.vcloud.task+xml" href="%s/api/task/%s">
+            <Link rel="task:cancel" href="%s/api/task/%s/action/cancel"/>
+            <Owner type="application/vnd.vmware.vcloud.vApp+xml" name="%s" href="%s/api/vApp/vapp-%s"/>
+            <User type="application/vnd.vmware.admin.user+xml" name="vcap" href="%s/api/admin/user/42cbe98d-48da-4f5d-944e-596843a9fcb5"/>
+            <Organization type="application/vnd.vmware.vcloud.org+xml" name="%s" href="%s/api/org/b689c06e-1de0-4fd1-a5a3-050c479546ac"/>
+            <Progress>1</Progress>
+        </Task>
+    </Tasks>
+    <Owner type="application/vnd.vmware.vcloud.owner+xml">
+        <User type="application/vnd.vmware.admin.user+xml" name="vcap" href="%s/api/admin/user/42cbe98d-48da-4f5d-944e-596843a9fcb5"/>
+    </Owner>
+    <InMaintenanceMode>false</InMaintenanceMode>
+</VApp>

--- a/spec/assets/test-director-config.yml
+++ b/spec/assets/test-director-config.yml
@@ -51,6 +51,7 @@ cloud:
             cookie_timeout: 1200 # timeout in seconds after which session must be re-created
             retry_max: 5 # maximum attempts
             retry_delay: 500 # delay of first retry, the next is * 2
+            old_task_threshold: 600 # ignore failed tasks older than this (minutes)
         control:
           retries:
             default: 5

--- a/spec/unit/vcloud/vcd_client_spec.rb
+++ b/spec/unit/vcloud/vcd_client_spec.rb
@@ -255,6 +255,7 @@ module VCloudCloud
         task.stub(:operation).and_return(task_operation)
         task.stub(:details).and_return(task_details)
         task.stub(:status).and_return VCloudSdk::Xml::TASK_STATUS[:ERROR]
+        
 
         entity.stub(:running_tasks) {[task]}
         entity.stub(:prerunning_tasks) {[]}
@@ -274,7 +275,8 @@ module VCloudCloud
         task.stub(:urn).and_return(task_id)
         task.stub(:operation).and_return(task_operation)
         task.stub(:details).and_return(task_details)
-
+        task.stub(:start_time).and_return Time.now
+        
         entity.stub(:running_tasks) {[]}
         entity.stub(:prerunning_tasks) {[]}
         entity.stub(:tasks) {[task, task]}
@@ -312,7 +314,10 @@ module VCloudCloud
         entity = double("entity")
         entity.stub(:tasks) {[task1,task2,task3]}
         
-        puts client.get_failed_tasks(entity)
+        failed_tasks = client.get_failed_tasks(entity)
+        
+        failed_tasks.length.should be 1
+        failed_tasks[0].start_time.should eq task3.start_time
       end
     end
   end

--- a/spec/unit/vcloud/vcd_client_spec.rb
+++ b/spec/unit/vcloud/vcd_client_spec.rb
@@ -12,13 +12,13 @@ module VCloudCloud
 
     describe '.initialize' do
       it 'read control settings from configuration file' do
-        verify_control_settings :@wait_max => 400, :@wait_delay => 10, :@retry_max => 5, :@retry_delay => 500, :@cookie_timeout => 1200
+        verify_control_settings :@wait_max => 400, :@wait_delay => 10, :@retry_max => 5, :@retry_delay => 500, :@cookie_timeout => 1200, :@old_task_threshold => 600
       end
 
       it 'use default control settings if not specified in configuration file' do
         settings['entities']['control'] = nil
         verify_control_settings :@wait_max => VCloudClient::WAIT_MAX, :@wait_delay => VCloudClient::WAIT_DELAY, \
-          :@retry_max => VCloudClient::RETRY_MAX, :@retry_delay => VCloudClient::RETRY_DELAY, :@cookie_timeout => VCloudClient::COOKIE_TIMEOUT
+          :@retry_max => VCloudClient::RETRY_MAX, :@retry_delay => VCloudClient::RETRY_DELAY, :@cookie_timeout => VCloudClient::COOKIE_TIMEOUT, :@old_task_threshold => VCloudClient::OLD_TASK_THRESHOLD
       end
 
       private
@@ -282,6 +282,37 @@ module VCloudCloud
         task_info = "Task #{task_id} #{task_operation}, Details:#{task_details}"
         raise_error_info =Regexp.new("Some tasks failed: #{task_info}; #{task_info}")
         expect{client.wait_entity(entity)}.to raise_error raise_error_info
+      end
+      
+      it "idenitifies an old task" do
+        task = double("task")
+        task.stub(:start_time).and_return Time.parse("2016-05-11T10:08:17.880+01:00")
+        client.old_task?(task).should eq true
+      end
+      
+      it "ignores newer tasks" do
+        task = double("task")
+        task.stub(:start_time).and_return Time.now - 60
+        client.old_task?(task).should eq false
+      end
+      
+      it "filters old tasks appropriately" do
+        task1 = double("task")
+        task1.stub(:status).and_return "failed"
+        task1.stub(:start_time).and_return Time.parse("2016-05-11T10:08:17.880+01:00")
+        
+        task2 = double("task")
+        task2.stub(:status).and_return "failed"
+        task2.stub(:start_time).and_return Time.parse("2016-05-11T10:08:17.880+01:00")
+        
+        task3 = double("task")
+        task3.stub(:status).and_return "failed"
+        task3.stub(:start_time).and_return Time.now
+        
+        entity = double("entity")
+        entity.stub(:tasks) {[task1,task2,task3]}
+        
+        puts client.get_failed_tasks(entity)
       end
     end
   end

--- a/spec/unit/vcloud/xml/task_spec.rb
+++ b/spec/unit/vcloud/xml/task_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+module VCloudSdk
+  module Xml
+    describe Task do
+      before(:each) do
+        @task_xml = ::File.open("assets/instantiated_vapp_power_task_running.xml").read
+        @task = WrapperFactory.wrap_document @task_xml
+      end
+      
+
+      
+      it "successfully creates a task object" do
+        
+        @task.should be_an_instance_of Task
+      end
+      
+      it "has a start_time property" do
+        @task.should respond_to(:start_time)
+      end
+      
+      it "returns a Time object" do
+        @task.start_time.should be_an_instance_of Time
+      end
+            
+      
+    end
+  
+  end
+end


### PR DESCRIPTION
vCloud maintains a list of historical tasks for a vApp. These tasks are returned in the <Tasks> Xml element of a GET vAPP response. 
When BOSH recomposes a vApp (to merge in new VMs for example) currently it aborts the BOSH Task if any failed tasks are identified. 
This PR enables a configurable time threshold @old_task_threshold which tells the vcd_client library to disregard tasks older than the value (in minutes). By default tasks older than an hour will be ignored.
